### PR TITLE
CSS import statements fail on windows

### DIFF
--- a/dist/PhotonDialog/dialog.js
+++ b/dist/PhotonDialog/dialog.js
@@ -66,7 +66,7 @@ module.exports = async function Dialog(e, options = {}) {
     dialog.webContents.on("did-finish-load", function() {
       dialog.webContents.executeJavaScript('document.querySelector(".modal-window").innerHTML = `' + template.replace(/`/g, "\\`") + '`;\n');
       if (templateScript.getAttribute("data-js")) {
-        dialog.webContents.executeJavaScript('var script = document.createElement("script"); script.async = true; script.type = "text/javascript"; script.src = "' + jsScript + '"; document.head.append(script);');
+        dialog.webContents.executeJavaScript('var script = document.createElement("script"); script.async = true; script.type = "text/javascript"; script.src = "' + jsScript.replace(/\\/g, "/") + '"; document.head.append(script);');
       }
     });
 

--- a/photon.js
+++ b/photon.js
@@ -116,7 +116,7 @@
         // Get the stylesheet's full path
         let styleSheetPath = componentBaseDir + "/" + components[componentName].style;
         // Append an @import statement to the styleheet of photon that refers to the components stylesheet
-        photonStyle.append('@import "' + styleSheetPath + '";');
+        photonStyle.append('@import "' + styleSheetPath.replace(/\\/g, "/") + '";');
       }
     }
   }


### PR DESCRIPTION
Photon is requiring the stylesheets for every component with `@import` statements. It's using the direct disk path which is correct for mac and linux but fails on windows because it's using backslashes.

To show the problem. The path `Document\selectron-photon\node_modules` will be the import statement `file:///Z:/ocumentselectron-photonnode_modules`. The backslashes are used (as intended) for escaping the following character.

The bugfix simply replaces the backslashes to normal slashes which fixes the problem for windows and has no effect for mac/linux.

