### PR TITLE
Changed extension of Object.prototype in helper.js

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -84,15 +84,18 @@ Object.defineProperty(Array.prototype, "last", {
     return this.lastFrom(0);
   }
 });
-Object.prototype.keyFromValue = function(value) {
-  for (var key in this) {
-    if (this.hasOwnProperty(key)) {
-      if (this[key] === value) {
-        return key;
+Object.defineProperty(Object.prototype, 'keyFromValue', {
+  enumerable: false,
+  value: function (value) {
+    for (var key in this) {
+      if (this.hasOwnProperty(key)) {
+        if (this[key] === value) {
+          return key;
+        }
       }
     }
   }
-};
+});
 Array.prototype.indexOfKey = function(value, key, start = 0) {
   for (var i = start; i < this.length; i++) {
     if (this[i][key] === value) {
@@ -109,6 +112,9 @@ Math.roundDeep = function(number, deepness = 0) {
   const multi = Math.pow(10, deepness);
   return Math.round(number * multi) / multi;
 };
-Object.prototype.fillDefaults = function(defaults) {
-  return module.exports.objFillDefaults(this, defaults);
-};
+Object.defineProperty(Object.prototype, 'fillDefaults', {
+  enumerable: false,
+  value: function (defaults) {
+    return module.exports.objFillDefaults(this, defaults);
+  }
+});


### PR DESCRIPTION
The two functions ```fillDefaults``` and ```keyFromValue``` were directly assigned to Object.prototpe. 
The direct assignment of prototype functions lead to  [[Enumerable]] object properties, see [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties).
Using ```Object.defineProperty(obj, prop, descriptor)```, see [MDN web docs](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty), they are now not enumerable and won't be listed e.g. in for in loops. 

This was a mayor issue for me, because it broke JQuery. 