### PR TITLE
Apply 'enumerable fix' to photon-browser.js; update ShowReel/main.js to work with electron >=  5.0.0.

### DIFF
--- a/ShowReel/main.js
+++ b/ShowReel/main.js
@@ -6,7 +6,8 @@ electron.app.on("ready", function() {
     height: 720,
     titleBarStyle: "hidden",
     webPreferences: {
-      experimentalFeatures: true
+      experimentalFeatures: true,
+      nodeIntegration: true
     }
   });
   window.loadURL("file://" + __dirname + "/index.html");

--- a/photon-browser.js
+++ b/photon-browser.js
@@ -2304,15 +2304,18 @@ Object.defineProperty(Array.prototype, "last", {
     return this.lastFrom(0);
   }
 });
-Object.prototype.keyFromValue = function(value) {
-  for (var key in this) {
-    if (this.hasOwnProperty(key)) {
-      if (this[key] === value) {
-        return key;
+Object.defineProperty(Object.prototype, 'keyFromValue', {
+  enumerable: false,
+  value: function (value) {
+    for (var key in this) {
+      if (this.hasOwnProperty(key)) {
+        if (this[key] === value) {
+          return key;
+        }
       }
     }
   }
-};
+});
 Array.prototype.indexOfKey = function(value, key, start = 0) {
   for (var i = start; i < this.length; i++) {
     if (this[i][key] === value) {
@@ -2329,9 +2332,12 @@ Math.roundDeep = function(number, deepness = 0) {
   const multi = Math.pow(10, deepness);
   return Math.round(number * multi) / multi;
 };
-Object.prototype.fillDefaults = function(defaults) {
-  return module.exports.objFillDefaults(this, defaults);
-};
+Object.defineProperty(Object.prototype, 'fillDefaults', {
+  enumerable: false,
+  value: function (defaults) {
+    return module.exports.objFillDefaults(this, defaults);
+  }
+});
 
 },{}],42:[function(require,module,exports){
 (function (process,__dirname){


### PR DESCRIPTION
- Include the Object.defineProperty enumerable=false fix in photon-browser.js. I had a change in both photon-browser.js and helper.js that (happily) matched the upstream fix, but noticed that the upstream version didn't include the corresponding change in photon-browser.
- Add a nodeIntegration=true flag to the electron main.js file in ShowReel which gives compatibility with electron versions 5.0.x+.