### PR TITLE
Fix ShowReel/main.js for Electron 10

### DIFF
--- a/ShowReel/main.js
+++ b/ShowReel/main.js
@@ -7,7 +7,8 @@ electron.app.on("ready", function() {
     titleBarStyle: "hidden",
     webPreferences: {
       experimentalFeatures: true,
-      nodeIntegration: true
+      nodeIntegration: true,
+      enableRemoteModule: true
     }
   });
   window.loadURL("file://" + __dirname + "/index.html");


### PR DESCRIPTION
In electron 10, remoteModule is set false by default.

This fixes [dist/PhotonMenu/dropdown.js](https://github.com/MauriceConrad/Photon/blob/master/dist/PhotonMenu/dropdown.js#L7) and possibly others.