### PR TITLE
Fix PhotonDialog for Electron 10

### DIFF
--- a/dist/PhotonDialog/dialog.js
+++ b/dist/PhotonDialog/dialog.js
@@ -48,7 +48,12 @@ else {
         //alwaysOnTop: true,
         vibrancy: "popover",
         modal: true,
-        //'use-content-size': true
+        //'use-content-size': true,
+        webPreferences: {
+          experimentalFeatures: true,
+          nodeIntegration: true,
+          enableRemoteModule: true
+        }
       }, options));
 
       const sheetOffset = photonWin.content.getBoundingClientRect().top;


### PR DESCRIPTION
As PhotonWindow, PhotonMenu, PhotonDropdown, & PhotonDialog use `electron.remote`, all Dialog subwindows that use Photon (= [all of them](https://github.com/MauriceConrad/Photon/blob/master/dist/PhotonDialog/templateModal.html#L7)) must have the security privileges `nodeIntegration` & `enableRemoteModule`.

Alternatively, the Dialog user could be required to pass such options in (e.g. in [app.js](https://github.com/MauriceConrad/Photon/blob/master/ShowReel/js/app.js#L22)).