### PR TITLE
Fix Dialog leaking event listeners

### DIFF
--- a/dist/PhotonDialog/dialog.js
+++ b/dist/PhotonDialog/dialog.js
@@ -62,13 +62,17 @@ else {
         });
       });
 
-      mainWindow.on("resize", function(event) {
-        dialog.setSheetOffset(sheetOffset);
+      const resizeCallback = function (event) {
+        dialog.setSheetOffset(sheetOffset)
         setModalPos(dialog, mainWindow, {
           x: 0,
           y: sheetOffset
-        });
-      });
+        })
+      }
+      dialog.on('close', function () {
+        mainWindow.off("resize", resizeCallback)
+      })
+      mainWindow.on("resize", resizeCallback)
 
       dialog.loadURL("file://" + __dirname + "/templateModal.html");
 


### PR DESCRIPTION
Every Dialog leaks an event listener to `mainWindow.on('resize', ...)` presently.  [These are not collected when the Dialog is closed](https://www.electronjs.org/docs/api/remote#passing-callbacks-to-the-main-process).  Meaning every `resize` event triggers 1 error for every closed Dialog, resulting in an explosion of console errors when then main window is resized after a few dialogs have been created and closed.  The fix is to remove the Dialog's listener at close.